### PR TITLE
Fix the permission for the public ecr

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ data "aws_iam_policy_document" "repository" {
       }
 
       actions = [
-        "ecr:BatchGetImage",
-        "ecr:GetDownloadUrlForLayer",
+        "ecr-public:BatchGetImage",
+        "ecr-public:GetDownloadUrlForLayer",
       ]
     }
   }
@@ -62,7 +62,7 @@ data "aws_iam_policy_document" "repository" {
   }
 
   dynamic "statement" {
-    for_each = length(var.repository_read_write_access_arns) > 0 ? [var.repository_read_write_access_arns] : []
+    for_each = length(var.repository_read_write_access_arns) > 0 && var.repository_type == "private" ? [var.repository_read_write_access_arns] : []
 
     content {
       sid = "ReadWrite"
@@ -77,6 +77,27 @@ data "aws_iam_policy_document" "repository" {
         "ecr:InitiateLayerUpload",
         "ecr:UploadLayerPart",
         "ecr:CompleteLayerUpload",
+      ]
+    }
+  }
+
+  dynamic "statement" {
+    for_each = length(var.repository_read_write_access_arns) > 0 && var.repository_type == "public" ? [var.repository_read_write_access_arns] : []
+
+    content {
+      sid = "ReadWrite"
+
+      principals {
+        type        = "AWS"
+        identifiers = statement.value
+      }
+
+      actions = [
+        "ecr-public:BatchCheckLayerAvailability",
+        "ecr-public:CompleteLayerUpload",
+        "ecr-public:InitiateLayerUpload",
+        "ecr-public:PutImage",
+        "ecr-public:UploadLayerPart",
       ]
     }
   }


### PR DESCRIPTION
## Description
Fix the ECR Permission policy for the public ECR repo.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Current permission policy created for public ecr repo are wrong.
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->